### PR TITLE
Add a bunch of trivial implications

### DIFF
--- a/lib/cong.gd
+++ b/lib/cong.gd
@@ -38,6 +38,7 @@ DeclareCategory( "IsCongruenceSubgroup", IsMatrixGroup );
 ##               [   N  1+N ]
 ##
 DeclareProperty( "IsPrincipalCongruenceSubgroup", IsCongruenceSubgroup );
+InstallTrueMethod(IsCongruenceSubgroup, IsPrincipalCongruenceSubgroup);
 
 
 #############################################################################
@@ -49,6 +50,7 @@ DeclareProperty( "IsPrincipalCongruenceSubgroup", IsCongruenceSubgroup );
 ##               [   N    * ]
 ##
 DeclareProperty( "IsCongruenceSubgroupGamma0", IsCongruenceSubgroup );
+InstallTrueMethod(IsCongruenceSubgroup, IsCongruenceSubgroupGamma0);
 
 
 #############################################################################
@@ -60,6 +62,7 @@ DeclareProperty( "IsCongruenceSubgroupGamma0", IsCongruenceSubgroup );
 ##               [   *    * ]
 ##
 DeclareProperty( "IsCongruenceSubgroupGammaUpper0", IsCongruenceSubgroup );
+InstallTrueMethod(IsCongruenceSubgroup, IsCongruenceSubgroupGammaUpper0);
 
 
 #############################################################################
@@ -71,6 +74,7 @@ DeclareProperty( "IsCongruenceSubgroupGammaUpper0", IsCongruenceSubgroup );
 ##               [   N  1+N ]
 ##
 DeclareProperty( "IsCongruenceSubgroupGamma1", IsCongruenceSubgroup );
+InstallTrueMethod(IsCongruenceSubgroup, IsCongruenceSubgroupGamma1);
 
 
 #############################################################################
@@ -82,6 +86,7 @@ DeclareProperty( "IsCongruenceSubgroupGamma1", IsCongruenceSubgroup );
 ##               [   *  1+N ]
 ##
 DeclareProperty( "IsCongruenceSubgroupGammaUpper1", IsCongruenceSubgroup );
+InstallTrueMethod(IsCongruenceSubgroup, IsCongruenceSubgroupGammaUpper1);
 
 
 #############################################################################
@@ -93,6 +98,7 @@ DeclareProperty( "IsCongruenceSubgroupGammaUpper1", IsCongruenceSubgroup );
 ##               [   N  1+N ]
 ##
 DeclareProperty( "IsCongruenceSubgroupGammaMN", IsCongruenceSubgroup );
+InstallTrueMethod(IsCongruenceSubgroup, IsCongruenceSubgroupGammaMN);
 
 
 #############################################################################
@@ -106,6 +112,7 @@ DeclareProperty( "IsCongruenceSubgroupGammaMN", IsCongruenceSubgroup );
 ## CongruenceSubgroupGamma^1 and CongruenceSubgroupGammaMN
 ##
 DeclareProperty( "IsIntersectionOfCongruenceSubgroups", IsCongruenceSubgroup );
+InstallTrueMethod(IsCongruenceSubgroup, IsIntersectionOfCongruenceSubgroups);
 
 
 #############################################################################


### PR DESCRIPTION
This makes various "hidden" implications created by DeclareProperty explicit, thus fixing a bunch of warnings that show up if one starts the upcoming GAP 4.11 with the `-N` command line option, and then loads this package.

For some information on the background of this, see also <https://github.com/gap-system/gap/issues/1649> and <https://github.com/gap-system/gap/issues/2336>