### PR TITLE
Update farey.gi

### DIFF
--- a/lib/farey.gi
+++ b/lib/farey.gi
@@ -79,7 +79,7 @@ InstallMethod( PrintObj,
     0,
     function(fs)
     Print( "FareySymbolByData( ", GeneralizedFareySequence(fs), 
-           ", ", LabelsOfFareySymbol(fs), " ] " );
+           ", ", LabelsOfFareySymbol(fs), " ) " );
     end);    
    
     


### PR DESCRIPTION
The printing function should print something like FareySymbolByData(...). 

This is needed to be able to get GAP readable code when printing stuff containing Farey symbols. 

This is correct: 
gap> FareySymbolByData( [ infinity, 0, 1, infinity ], [ "odd", 3, 3 ] );
[ infinity, 0, 1, infinity ]
[ "odd", 3, 3 ]

This is not and is what the package prints: 
gap> FareySymbolByData( [ infinity, 0, 1, infinity ], [ "odd", 3, 3 ] ];
